### PR TITLE
Performance:  Add Setup step ,"Create external directory", to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ grunt build
 ## Setup
 
 * Follow the steps for building above
+* Create directories for saving external files (`mkdir -p external/selenium`)
 * Ensure you have both firefox and chrome browsers installed
 * Download CouchDB from [http://couchdb.apache.org/#download](http://couchdb.apache.org/#download)
 * Start CouchDB


### PR DESCRIPTION
After building and before running first performance tests with `grunt perf` , user must create directories where downloaded external files (selenium jar file) will be stored.