### PR TITLE
Build: Move download location to be within the node module

### DIFF
--- a/tasks/options/start-selenium-server.js
+++ b/tasks/options/start-selenium-server.js
@@ -3,7 +3,7 @@ module.exports = {
 		options: {
 			downloadUrl: "https://selenium-release.storage.googleapis.com/2.45/" +
 				"selenium-server-standalone-2.45.0.jar",
-			downloadLocation: "external/selenium",
+			downloadLocation: "node_modules/grunt-selenium-server/",
 			serverOptions: {
 				"Dwebdriver.chrome.driver=node_modules/chromedriver/bin/chromedriver": ""
 			},


### PR DESCRIPTION
This will make it so that cleaning out the node_modules folder will also
remove the selenium server and avoid the need to create a directory to put
it in.

Closes gh-44