### PR TITLE
Build: Add CI testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 external/
 icons/svg-min/
 .sass-cache/
+css

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: node_js
+node_js:
+  - "0.10"
+cache:
+  directories:
+  - node_modules
+script:
+  - "grunt"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,8 +16,22 @@ var config = {
 						"ie >= 8"
 					]
 				},
-				src: "*.css"
+				src: "css/*.css"
 			}
+		},
+		cssmin: {
+			options: {
+				report: "gzip",
+				sourceMap: true
+			},
+			target: {
+				files: {
+					"css/chassis.min.css": "css/style.min.css"
+				}
+			}
+		},
+		csslint: {
+			src: [ "css/*.css" ]
 		},
 		jscs: {
 			all: [ "*.js", "performance/*.js", "performance/frameworks/*.js" ]
@@ -29,16 +43,33 @@ var config = {
 			}
 		},
 		sass: {
-			dist: {
+			min: {
 				options: {
 					sourceMap: true,
+					outFile: "/css/chassis.css",
 					outputStyle: "compressed"
 				},
 				files: [ {
 					expand: true,
 					cwd: "scss",
 					src: [ "*.scss" ],
-					dest: "",
+					dest: "dist/css/",
+					ext: ".min.css"
+				} ]
+			},
+			dist: {
+				options: {
+					sourceMap: false,
+					outFile: "/css/chassis.css",
+
+					// This actually does nested until libsass updates to support expanded
+					outputStyle: "expanded"
+				},
+				files: [ {
+					expand: true,
+					cwd: "scss",
+					src: [ "*.scss" ],
+					dest: "dist/css/",
 					ext: ".css"
 				} ]
 			}
@@ -127,8 +158,9 @@ grunt.util._.extend( config, loadConfig( "./tasks/options/" ) );
 grunt.initConfig( config );
 grunt.loadTasks( "tasks" );
 grunt.loadNpmTasks( "perfjankie" );
-grunt.registerTask( "default", [ "jshint", "jscs" ] );
-grunt.registerTask( "build", [ "svg", "sass", "autoprefixer" ] );
+grunt.registerTask( "default", [ "build", "test" ] );
+grunt.registerTask( "test", [ "build", "jshint", "jscs", "csslint" ] );
+grunt.registerTask( "build", [ "svg", "sass", "autoprefixer", "cssmin" ] );
 grunt.registerTask( "perf", [
 	"start-selenium-server",
 	"connect:perf",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
 		"glob": "4.4.2",
 		"grunt": "0.4.5",
 		"grunt-autoprefixer": "2.1.0",
+		"grunt-contrib-cssmin": "0.10.0",
+		"grunt-contrib-csslint": "0.4.0",
 		"grunt-contrib-jshint": "0.10.0",
 		"grunt-contrib-connect": "0.9.0",
 		"grunt-contrib-watch": "0.6.1",


### PR DESCRIPTION
Adds a test task which runs on travis also add csslint and cssmin,
this also moves all generated css to a dist/css folder and adds a non minified
version of the css as well.