### PR TITLE
Performance: Add Dojo Widget to test suite

### DIFF
--- a/performance/frameworks/dojo.js
+++ b/performance/frameworks/dojo.js
@@ -24,7 +24,7 @@ module.exports = {
 				button += " dijitDisplayNone";
 			}
 
-			button += " '>cut</span></span></span>" +
+			button += " '>button</span></span></span>" +
 				"<input type='button' value='' class='dijitOffScreen' " +
 				"aria-hidden='true'></span></span>";
 			return button;

--- a/performance/frameworks/dojo.js
+++ b/performance/frameworks/dojo.js
@@ -1,0 +1,49 @@
+module.exports = {
+	css: [ "//ajax.googleapis.com/ajax/libs/dojo/1.10.3/dijit/themes/claro/claro.css" ],
+	button: {
+		generator: function( options ) {
+			var button = "<span class='claro'><span class='dijit dijitReset " +
+				"dijitInline dijitButton'>" +
+				"<span class='dijitReset dijitInline dijitButtonNode'>" +
+				"<span class='dijitReset dijitStretch dijitButtonContents'>" +
+				"<span class='dijitReset dijitInline dijitIcon";
+
+			// Show icon if Icon is set, or button type is only-icon
+			if ( options.icon || options.type ) {
+				button += " dijitEditorIcon dijitEditorIcon" + options.icon;
+			} else {
+				button += " dijitNoIcon";
+			}
+
+			button += "'></span>" +
+				"<span class='dijitReset dijitToggleButtonIconChar'>●</span>" +
+				"<span class='dijitReset dijitInline dijitButtonText ";
+
+			// Check if Button text is to be displayed
+			if ( options.type ) {
+				button += " dijitDisplayNone";
+			}
+
+			button += " '>cut</span></span></span>" +
+				"<input type='button' value='' class='dijitOffScreen' " +
+				"aria-hidden='true'></span></span>";
+			return button;
+		},
+		variations: {
+			type: [
+				"",
+				"icon-only"
+			],
+
+			icon: [
+				"",
+				"Cut",
+				"Save",
+				"Bold",
+				"Underline",
+				"Copy"
+			]
+
+		}
+	}
+};

--- a/tasks/options/perfjankie.js
+++ b/tasks/options/perfjankie.js
@@ -32,7 +32,9 @@ module.exports = {
 				"http://localhost:4200/framework/topcoat/component/button/count/1000/" +
 					"topcoat:button",
 				"http://localhost:4200/framework/topcoat-mobile/component/button/count/1000/" +
-					"topcoat-mobile:button"
+					"topcoat-mobile:button",
+				"http://localhost:4200/framework/dojo/component/button/count/1000/" +
+					"dojo:button"
 			]
 		}
 	}


### PR DESCRIPTION
This PR adds Dojo Widget (dijit) test to the test suite .
[Link to the documentation dijit/form/Button](http://dojotoolkit.org/reference-guide/1.10/dijit/form/Button.html#dijit-form-button)

There are not many variants I could figure out from the documentation. Though there are combo buttons, I have not added those because similar combo-button with dropdown are available in other frameworks like bootstrap, and they were not added in test suite, hence, it would not have been a fair comaprison.