### PR TITLE
Dependencies: Updated grunt-sass to 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"grunt-git-authors": "2.0.0",
 		"grunt-html": "1.6.0",
 		"grunt-jscs": "0.6.2",
-		"grunt-sass": "0.17.0",
+		"grunt-sass": "0.18.1",
 		"grunt-selenium-server": "0.1.2",
 		"grunt-svgmin": "2.0.0",
 		"grunt-svgstore": "0.5.0",


### PR DESCRIPTION
Updated grunt-sass from 0.17.0 to 0.18.1, to make it compatible with Node.js v. 0.12.*. 

This imply updating (from grunt-sass) node-sass from version 1.2.3 to 2.0.1. 

Now build works fine both on Node.js 0.10.* and 0.12.*

Tested on Win.8, both Node.js 0.10 and 0.12
