### PR TITLE
Performance: Add checkbox to performance suite

### DIFF
--- a/performance/frameworks/dojo.js
+++ b/performance/frameworks/dojo.js
@@ -45,5 +45,35 @@ module.exports = {
 			]
 
 		}
+	},
+	checkbox: {
+		generator: function( options ) {
+			var checkbox = "<span class='claro'><div class='dijit dijitReset" +
+				" dijitInline dijitCheckBox",
+				input = "<input type='checkbox' class='dijitReset dijitCheckBoxInput' ";
+			if ( options.checked ) {
+				checkbox += " dijitCheckBoxChecked dijitChecked";
+				input += " checked='checked'";
+			}
+			if ( options.disabled ) {
+				checkbox += " dijitCheckBoxDisabled dijitDisabled";
+				input += " disabled=''";
+			}
+			if ( options.checked && options.disabled ) {
+				checkbox += " dijitCheckBoxCheckedDisabled dijitCheckedDisabled";
+			}
+			return checkbox + "' >" + input + " />" + "</div><label>checkbox</label></span>";
+
+		},
+		variations: {
+			checked: [
+				false,
+				true
+			],
+			disabled: [
+				false,
+				true
+			]
+		}
 	}
 };

--- a/performance/frameworks/jquery-ui-1-12.js
+++ b/performance/frameworks/jquery-ui-1-12.js
@@ -39,5 +39,44 @@ module.exports = {
 				"heart"
 			]
 		}
+	},
+	checkbox: {
+		generator: function( options ) {
+			var label = "<label class='ui-checkboxradio-label ui-corner-all ui-button ui-widget",
+				input = "<input type='checkbox' class='ui-checkboxradio" +
+				" ui-helper-hidden-accessible'",
+				icon = "";
+			if ( options.checked ) {
+				label += " ui-checkboxradio-checked ui-state-active";
+				input += " checked";
+			}
+			if ( options.disabled ) {
+				label += " ui-checkboxradio-disabled ui-state-disabled";
+				input += " disabled";
+			}
+			if ( options.icon ) {
+				icon = "<span class='ui-checkboxradio-icon ui-corner-all ui-icon" +
+				" ui-icon-background ui-state-hover ui-icon-blank";
+				if ( options.checked ) {
+					icon += " ui-icon-check ui-state-highlight";
+				}
+				icon += " '></span><span> </span>";
+			}
+			return label + "'>" + icon + "checkbox</label>" + input + " />";
+		},
+		variations: {
+			checked: [
+				false,
+				true
+			],
+			disabled: [
+				false,
+				true
+			],
+			icon: [
+				true,
+				false
+			]
+		}
 	}
 };

--- a/performance/frameworks/semantic-ui.js
+++ b/performance/frameworks/semantic-ui.js
@@ -57,16 +57,16 @@ module.exports = {
 	},
 	checkbox: {
 		generator: function( options ) {
-			var checkbox = "<div class='ui checkbox '",
+			var checkbox = "<div class='ui checkbox",
 				input = "<input type='checkbox'";
 			if ( options.checked ) {
-				checkbox += "checked";
+				checkbox += " checked";
 				input += " checked='checked'";
 			}
 			if ( options.disabled ) {
 				input += " disabled='disabled'";
 			}
-			return checkbox + ">" + input + " />" + "<label>checkbox</label></div>";
+			return checkbox + "'>" + input + " />" + "<label>checkbox</label></div>";
 
 		},
 		variations: {

--- a/performance/frameworks/semantic-ui.js
+++ b/performance/frameworks/semantic-ui.js
@@ -54,5 +54,30 @@ module.exports = {
 				" toggle"
 			]
 		}
+	},
+	checkbox: {
+		generator: function( options ) {
+			var checkbox = "<div class='ui checkbox '",
+				input = "<input type='checkbox'";
+			if ( options.checked ) {
+				checkbox += "checked";
+				input += " checked='checked'";
+			}
+			if ( options.disabled ) {
+				input += " disabled='disabled'";
+			}
+			return checkbox + ">" + input + " />" + "<label>checkbox</label></div>";
+
+		},
+		variations: {
+			checked: [
+				false,
+				true
+			],
+			disabled: [
+				false,
+				true
+			]
+		}
 	}
 };

--- a/performance/frameworks/topcoat-mobile.js
+++ b/performance/frameworks/topcoat-mobile.js
@@ -52,5 +52,22 @@ module.exports = {
 			]
 
 		}
+	},
+	checkbox: {
+		generator: function( options ) {
+			return "<label class='topcoat-checkbox'><input type='checkbox' " +
+				options.checked + options.disabled + " /><div class=" +
+				"'topcoat-checkbox__checkmark'></div>checkbox</label>";
+		},
+		variations: {
+			checked: [
+				"",
+				" checked='checked'"
+			],
+			disabled: [
+				"",
+				" disabled='disabled'"
+			]
+		}
 	}
 };

--- a/performance/frameworks/topcoat.js
+++ b/performance/frameworks/topcoat.js
@@ -52,5 +52,22 @@ module.exports = {
 			]
 
 		}
+	},
+	checkbox: {
+		generator: function( options ) {
+			return "<label class='topcoat-checkbox'><input type='checkbox' " +
+				options.checked + options.disabled + " /><div class=" +
+				"'topcoat-checkbox__checkmark'></div>checkbox</label>";
+		},
+		variations: {
+			checked: [
+				"",
+				" checked='checked'"
+			],
+			disabled: [
+				"",
+				" disabled='disabled'"
+			]
+		}
 	}
 };

--- a/tasks/options/perfjankie.js
+++ b/tasks/options/perfjankie.js
@@ -44,7 +44,9 @@ module.exports = {
 				"http://localhost:4200/framework/semantic-ui/component/checkbox/count/1000/" +
 					"semantic-ui:checkbox-widget",
 				"http://localhost:4200/framework/dojo/component/checkbox/count/1000/" +
-					"dojo:checkbox-widget"
+					"dojo:checkbox-widget",
+				"http://localhost:4200/framework/jquery-ui-1-12/component/checkbox/count/1000/" +
+					"jquery-ui-1-12:checkbox-widget"
 			]
 		}
 	}

--- a/tasks/options/perfjankie.js
+++ b/tasks/options/perfjankie.js
@@ -36,7 +36,13 @@ module.exports = {
 				"http://localhost:4200/framework/semantic-ui/component/button/count/1000/" +
 					"semantic-ui:button",
 				"http://localhost:4200/framework/dojo/component/button/count/1000/" +
-					"dojo:button"
+					"dojo:button",
+				"http://localhost:4200/framework/topcoat/component/checkbox/count/1000/" +
+					"topcoat:checkbox-widget",
+				"http://localhost:4200/framework/topcoat-mobile/component/checkbox/count/1000/" +
+					"topcoat-mobile:checkbox-widget",
+				"http://localhost:4200/framework/semantic-ui/component/checkbox/count/1000/" +
+					"semantic-ui:checkbox-widget"
 			]
 		}
 	}

--- a/tasks/options/perfjankie.js
+++ b/tasks/options/perfjankie.js
@@ -42,7 +42,9 @@ module.exports = {
 				"http://localhost:4200/framework/topcoat-mobile/component/checkbox/count/1000/" +
 					"topcoat-mobile:checkbox-widget",
 				"http://localhost:4200/framework/semantic-ui/component/checkbox/count/1000/" +
-					"semantic-ui:checkbox-widget"
+					"semantic-ui:checkbox-widget",
+				"http://localhost:4200/framework/dojo/component/checkbox/count/1000/" +
+					"dojo:checkbox-widget"
 			]
 		}
 	}


### PR DESCRIPTION
Adds checkbox to performance testing for following frameworks:
+ topcoat
+ topcoat-mobile
+ semantic-ui

I am adding checkbox to more frameworks, hence we can consider this as **In Progress**