### PR TITLE
[hidden] { display: none !important; }

### DIFF
--- a/scss/_utilities/_hidden.scss
+++ b/scss/_utilities/_hidden.scss
@@ -1,0 +1,17 @@
+/*
+* ==========================================================================
+* Hidden attribute
+*
+* Make the [hidden] global HTML attribute much more useful.
+* It's intended to be used to hide elements, but since it's not `!important`
+* by default, it's normally trumped by mere CSS classes that were only meant
+* to set a default `display` value. Making it `!important` (which is fine
+* because this is a utility attribute) corrects this shortcoming.
+* https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute
+* https://html.spec.whatwg.org/multipage/rendering.html#hiddenCSS
+* ==========================================================================
+*/
+
+[hidden] {
+	display: none !important;
+}

--- a/scss/lint.scss
+++ b/scss/lint.scss
@@ -11,7 +11,8 @@
 
 @import
 	"_utilities/clearfix",
-	"_utilities/colors";
+	"_utilities/colors",
+	"_utilities/hidden";
 
 @import
 	"atoms/icons/icons",

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -3,7 +3,8 @@
 // ==========================================================================
 
 @import
-	"_utilities/clearfix";
+	"_utilities/clearfix",
+	"_utilities/hidden";
 
 @import
 	"atoms/icons/icons",


### PR DESCRIPTION
The `[hidden]` attribute is pretty useless without this. With this, it has a chance at being The One True Way to toggle the hiddenness of an element and communicate its shown/hidden status across frameworks.
This touches on some of the issues with `.show()`/`.hide()` mentioned in http://blog.jquery.com/2015/07/13/jquery-3-0-and-jquery-compat-3-0-alpha-versions-released/
See the comment in `_hidden.scss` for more explanation.