### PR TITLE
Documentation: Add note about running Grunt tests to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ To automate the build process during development, run the `grunt watch` task to 
 $ grunt watch
 ```
 
-### Travis CI Tests
+### Grunt Tests
 
-To run the Travis tests locally, run the `grunt test` task. It's a good idea to run the tests before committing to avoid having failed tests in your PRs.
+To run the grunt tests locally, run the `grunt test` task. It's a good idea to run the tests before committing to avoid having failed tests in your PRs.
 
 ```bash
 $ grunt test

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ To automate the build process during development, run the `grunt watch` task to 
 $ grunt watch
 ```
 
+### Travis CI Tests
+
+To run the Travis tests locally, run the `grunt test` task. It's a good idea to run the tests before committing to avoid having failed tests in your PRs.
+
+```bash
+$ grunt test
+```
+
 ### Performance testing
 
 #### Setup

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ $ grunt watch
 
 ### Grunt Tests
 
-To run the grunt tests locally, run the `grunt test` task. It's a good idea to run the tests before committing to avoid having failed tests in your PRs.
+To run the tests locally run:
 
 ```bash
 $ grunt test
 ```
+Make sure you run the tests before creating a pull request.
 
 ### Performance testing
 


### PR DESCRIPTION
I noticed it wasn't stated in the readme file how to run the Grunt tests. I think seeing that note will help me remember to run the tests before committing and I'm sure will be helpful for others as well.