### PR TITLE
Build: Fix and include Normalize in dist

### DIFF
--- a/scss/lint.scss
+++ b/scss/lint.scss
@@ -11,7 +11,6 @@
 
 @import
 	"_utilities/clearfix",
-	"_utilities/colors",
 	"_utilities/functions",
 	"_utilities/hidden";
 

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,16 +1,11 @@
-// ==========================================================================
-// CSS Chassis
-// ==========================================================================
+/*
+* ==========================================================================
+* CSS Chassis
+*
+* This adds normalize.css to the build see lint.scss for expanation
+* ==========================================================================
+*/
 
 @import
-	"_utilities/clearfix",
-	"_utilities/functions",
-	"_utilities/hidden";
-
-@import
-	"atoms/icons/icons",
-	"atoms/typography/typography",
-	"atoms/buttons/buttons";
-
-@import
-	"views/main";
+	"external/normalize.css/normalize",
+	"scss/lint";

--- a/tasks/options/csslint.js
+++ b/tasks/options/csslint.js
@@ -1,5 +1,5 @@
 module.exports = {
-	src: [ "dist/css/*.css" ],
+	src: [ "dist/css/chassis.lint.css", "dist/css/chassis.lint.css" ],
 	options: {
 		csslintrc: ".csslintrc"
 	}

--- a/tasks/options/sass.js
+++ b/tasks/options/sass.js
@@ -1,4 +1,6 @@
 module.exports = {
+
+	// This is everything including normalize.css see lint below for explanation
 	dist: {
 		options: {
 			sourceMap: true,
@@ -8,6 +10,19 @@ module.exports = {
 		},
 		files: {
 			"dist/css/chassis.css": "scss/style.scss"
+		}
+	},
+
+	// This is everything except normalize.css as normalize won't pass our lint settings
+	lint: {
+		options: {
+			sourceMap: true,
+
+			// This actually does nested until libsass updates to support expanded
+			outputStyle: "expanded"
+		},
+		files: {
+			"dist/css/chassis.lint.css": "scss/lint.scss"
 		}
 	}
 };


### PR DESCRIPTION
As discussed in meeting, inclusion of normalize in dist was broken. This PR fixes that and also corrects linting task to lint chassis.lint.css .
