### PR TITLE
Typography: change the unit measurement from 'em' to 'rem'

### DIFF
--- a/scss/atoms/typography/_functions.scss
+++ b/scss/atoms/typography/_functions.scss
@@ -11,6 +11,6 @@
 * 1. font-size: em(14px);
 * 2. font-size: em(30px/14px);
 */
-@function em($value, $context: map-get($typography-font-default, font-size)) {
-	@return ($value / $context * 1em);
+@function rem($value, $context: map-get($typography-font-default, font-size)) {
+	@return ($value / $context * 1rem);
 }

--- a/scss/atoms/typography/_mixins.scss
+++ b/scss/atoms/typography/_mixins.scss
@@ -4,7 +4,7 @@
 * ==========================================================================
 */
 @mixin heading($style) {
-	font-size: em(map-get($style,font-size));
+	font-size: rem(map-get($style,font-size));
 	font-weight: map-get($style,font-weight);
 	line-height: 1;
 	text-transform: map-get($style,capitalization);

--- a/scss/atoms/typography/_typography.scss
+++ b/scss/atoms/typography/_typography.scss
@@ -110,7 +110,7 @@ strong {
 
 code {
 	background: map-get($typography-code,background);
-	font-size: em( 16px );
-	padding: em( 4px, 16px ) em( 8px, 16px );
+	font-size: rem( 16px );
+	padding: rem( 4px, 16px ) rem( 8px, 16px );
 	border-radius: map-get($typography-code,border-radius);
 }


### PR DESCRIPTION
I tried to refactor the code and changed the em converter to rem since it would be better to use rem. em would cause problems when 2-3 elements are nested. Opinions?